### PR TITLE
Enable automatic resume of dev cycle

### DIFF
--- a/.github/workflows/resume-dev-cycle.yml
+++ b/.github/workflows/resume-dev-cycle.yml
@@ -1,0 +1,34 @@
+name: Resume Dev Cycle
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  resume:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Resume development cycle
+        run: |
+          python nimda_agent_plugin/resume_dev_cycle.py
+      - name: Commit and push changes
+        run: |
+          git config --local user.email "nimda-agent@noreply.github.com"
+          git config --local user.name "NIMDA Agent"
+          git add -A
+          if ! git diff --cached --quiet; then
+            git commit -m "Automated resume of development cycle"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ python nimda_agent_plugin/auto_dev_runner.py /path/to/project
 
 The script initializes the project (if required), runs the full development cycle and executes tests when they are available.
 
+If the process is interrupted for any reason, you can resume execution with:
+
+```bash
+python nimda_agent_plugin/resume_dev_cycle.py
+```
+
 ## Repository structure
 
 ```

--- a/resume_dev_cycle.py
+++ b/resume_dev_cycle.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Resume NIMDA development cycle if tasks remain unfinished."""
+
+from pathlib import Path
+
+from agent import NIMDAAgent
+from auto_dev_runner import run_cycle_until_complete, STATE_FILE
+
+
+def main() -> None:
+    project_path = Path(".").resolve()
+    agent = NIMDAAgent(str(project_path))
+
+    status = agent.dev_plan_manager.get_plan_status()
+    if status["completed_tasks"] >= status["total_tasks"]:
+        print("Development plan already completed.")
+        return
+
+    print(
+        f"Resuming development cycle: {status['completed_tasks']}/{status['total_tasks']} tasks completed"
+    )
+
+    state_file = project_path / STATE_FILE
+    state_file.write_text("resume")
+
+    run_cycle_until_complete(agent)
+
+    if state_file.exists():
+        state_file.unlink()
+
+    agent.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- ensure auto_dev_runner loops until the plan completes and writes a state file
- add resume_dev_cycle helper script
- restart unfinished cycles from `codex_monitor.sh`
- schedule new `resume-dev-cycle` GitHub workflow
- document resume command in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68747f0f721483279382c2633ee9dbfc